### PR TITLE
Support for tooltip popups

### DIFF
--- a/lib/helpBalloon-1.0.tm
+++ b/lib/helpBalloon-1.0.tm
@@ -1,0 +1,99 @@
+#
+# From DAS on Tcl Wiki
+#
+# Daniel Steffen - http://www.maths.mq.edu.au/~steffen/tcltk
+# Modified and updated by Clif Flynt http://www.noucorp.com
+#   Converted to use namespaces
+#   Converted to tcl module.
+
+package provide helpBalloon 1.0
+
+proc balloon {w help} {
+    bind $w <Any-Enter> "after 1000 [list balloon::show %W [list $help]]"
+    bind $w <Any-Leave> "destroy %W.balloon"
+}
+
+namespace eval balloon {
+################################################################
+#  proc show {w text }--
+#    display a help balloon if the cursor is within window w
+# Arguments
+#  w	The name of the window for the help
+#  text	The text to display in the window
+# Results
+#  Destroys any existing window, and creates a new 
+#   toplevel window containing a message widget with
+#   the help text
+
+ proc show {w text} {
+    
+    # Get the name of the window containing the cursor.
+
+    set currentWin [eval winfo containing  [winfo pointerxy .]]
+    
+    # If the current window is not the one that requested the
+    #   help, return.
+
+    if {![string match $currentWin $w]} {
+        return
+    }
+
+    # The  new toplevel window will be a child of the 
+    #  window that requested help.
+
+    set top $w.balloon
+
+    # Destroy any previous help balloon
+
+    catch {destroy $top}
+    
+    # Create a new toplevel window, and turn off decorations
+    toplevel $top -borderwidth 1 
+    wm overrideredirect $top 1
+
+    # If Macintosh, do a little magic.
+
+    if {$::tcl_platform(platform) == "macintosh"} {
+
+    # Daniel A. Steffen added an 'unsupported1' command
+    # to make this work on macs as well, otherwise
+    # raising the balloon window would immediately
+    # post a Leave event leading to the destruction
+    # of the balloon... The 'unsupported1' command
+    # makes the balloon window into a floating
+    # window which does not put the underlying
+    # window into the background and thus avoids
+    # the problem. (For this to work, appearance 
+    # manager needs to be present
+    # 
+    # In Tk 8.4, this command is renamed to:
+    #  ::tk::unsupported::MacWindowStyle
+
+     unsupported1 style $top floating sideTitlebar
+    }
+
+    # Create and pack the message object with the help text
+
+    pack [message $top.txt -aspect 200 -background lightyellow \
+            -font fixed -text $text]
+
+    # Get the location of the window requesting help,
+    #  use that to calculate the location for the new window.
+
+    set wmx [winfo rootx $w]
+    set wmy [expr [winfo rooty $w]+[winfo height $w]]
+    wm geometry $top \
+      [winfo reqwidth $top.txt]x[winfo reqheight $top.txt]+$wmx+$wmy
+    
+    # Raise the window, to be certain it's not hidden below
+    #  other windows.
+    raise $top
+  }
+}
+
+if {[info exists argv] && ([string first -testBalloon $argv] >= 0)} {
+ # Example:
+  button  .b -text Exit -command exit
+  balloon .b "Push me if you're done with this"
+  pack    .b
+}

--- a/lib/topoSort-1.0.tm
+++ b/lib/topoSort-1.0.tm
@@ -1,0 +1,83 @@
+package provide topoSort 1.0
+
+namespace eval topoSort {
+  namespace export topoSort
+################################################################
+# proc topoSort {nodes}--
+#    Return a sorted list of indices
+# Arguments
+#   nodes:  A list of edges - 
+#  {{node1 {edge1.2 edge1.3}} {node2 {edge2.3 edge2.4}} {node3 {} }}
+# 
+# Results
+#   Returns a list of nodes in sorted order.
+# 
+proc topoSort {nodes} {
+    set sortlst ""
+    set rtnList ""
+    set nodes [cleanit $nodes]
+
+    while {[llength $nodes] > 0} {
+        set l1 [findTerminal $nodes]
+	if {[string match $l1 ""]} {
+	    foreach n $nodes {
+	        lappend rtnList [lindex $n 0]
+	    }
+	    break;
+	}
+	set nodes [purge $nodes $l1]
+	append rtnList " " $l1
+    }
+    return $rtnList
+}
+
+proc cleanit {list} {
+    set rtnList {}
+    foreach i $list {
+        lappend nodes [lindex $i 0]
+    }
+    foreach i $list {
+        set l3 ""
+	set i0 [lindex $i 0]
+        foreach i1 [lindex $i 1] {
+	    if {([lsearch $nodes $i1] >= 0) &&
+	        (![string match $i1 $i0])} {
+	        lappend l3 $i1
+	    }
+	}
+	lappend rtnList [list $i0 $l3]
+    }
+    return $rtnList
+}
+
+proc findTerminal {list } {
+    set emptys ""
+
+    foreach l $list {
+        if {[llength [lindex $l 1]] == 0} {
+	    lappend emptys [lindex $l 0]
+	}
+    }
+    
+    return $emptys
+}
+
+proc purge {list1 list2} {
+    set l3 ""
+    foreach l1 $list1 {
+        set l [lindex $l1 1]
+        foreach l2 $list2 {
+	    if {[set pos [lsearch $l $l2 ]] >= 0} {
+	        set l [lreplace $l $pos $pos]
+	    }
+	}
+	if {[lsearch $list2 [lindex $l1 0]] < 0} {
+	    # puts "lsearch $list2 [lindex $l1 0] [lsearch $list2 [lindex $l1 0]] "
+	    lappend l3 [list [lindex $l1 0] $l]
+	}
+    }
+return $l3
+}
+
+}
+

--- a/main.tcl
+++ b/main.tcl
@@ -5,6 +5,8 @@
 ################################################################################
 set TloonaVersion {}
 
+tk appname Tloona
+
 set ::TloonaRoot [file normalize [file dirname [info script]]]
 set ::TloonaApplication .tloona
 # adjust auto_path
@@ -13,6 +15,7 @@ set env(ITCL_LIBRARY) [file join $::TloonaRoot lib itcl4.0.3]
 set auto_path [linsert $auto_path 0 [file join $::TloonaRoot src] [file join $::TloonaRoot lib]]
 
 package require tmw::splash 1.0
+
 
 # create the splash screen
 Tmw::Splash::Create -topdir $::TloonaRoot -showprogress 1 -title Tloona
@@ -50,6 +53,8 @@ Tmw::Splash::Progress 30
 
 puts "Tloona comm ID: [set ::CommId [::comm::comm self]]"
 source [file join $::TloonaRoot src toolbutton.tcl]
+source [file join $::TloonaRoot src tclFlow.tcl]
+
 
 # Toolbar options
 # See toolbutton.tcl.

--- a/src/codebrowser.tcl
+++ b/src/codebrowser.tcl
@@ -67,22 +67,28 @@ snit::widgetadaptor codebrowser {
         
         # create a toolbar with codebrowser specific actions
         set toolBar [$self toolbar tools -pos n -compound none]
-        $self toolbutton sortalpha -toolbar tools -image $Tmw::Icons(SortAlpha) \
+	
+        set w [$self toolbutton sortalpha -toolbar tools -image $Tmw::Icons(SortAlpha) \
             -type checkbutton -variable [myvar options(-sortalpha)] -separate 0 \
-            -command [mymethod onSort]
-        $self toolbutton sortseq -toolbar tools -image $Icons(SortSeq) \
+            -tip "Alphabet sort" -command [mymethod onSort]]
+
+        set w [$self toolbutton sortseq -toolbar tools -image $Icons(SortSeq) \
             -type checkbutton -variable [myvar options(-dosortseq)] -separate 0 \
-            -command [mymethod onSort]
-        set f [$self dropframe sortseqcfg -toolbar tools -image $Icons(SortSeqCfg) \
-            -separate 0 -hidecmd [mymethod UpdateSortSeq] -relpos 0]
+            -tip "Sequence sort" -command [mymethod onSort]]
+
+        set w [set f [$self dropframe sortseqcfg -toolbar tools -image $Icons(SortSeqCfg) \
+            -tip "Modify Sort Order" -separate 0 -hidecmd [mymethod UpdateSortSeq] -relpos 0]]
         
         $self CreateSortList $f
         
         set Filter(pattern) ""
         ttk::entry $toolBar.efilter -textvariable [myvar Filter(pattern)] -width 15
         set Filter(widgets) $toolBar.efilter
-        $self toolbutton filter -toolbar tools -image $Tmw::Icons(ActFilter) \
-            -type command -separate 0 -command [mymethod onFilter] -stickto back
+
+        set w [$self toolbutton filter -toolbar tools -image $Tmw::Icons(ActFilter) \
+            -type command -separate 0 -command [mymethod onFilter] -stickto back]
+        balloon $w "Filter report"
+
         pack $toolBar.efilter -expand n -fill none -side right -padx 2 -pady 1
         bind $toolBar.efilter <Return> [mymethod onFilter]
     }

--- a/src/mainapp.tcl
+++ b/src/mainapp.tcl
@@ -1,8 +1,8 @@
 ## mainapp.tcl (created by Tloona here)
-
 ::tcl::tm::path add lib
 
 package require helpBalloon
+package require topoSort
 
 package require snit 2.3.2
 package require tmw::platform 2.0.0
@@ -804,6 +804,8 @@ snit::widgetadaptor mainapp {
                         $fCls addToFileBrowser $kitbrowser
                     }
                     update
+                    tclFlow::addFile $uri
+                    ::tclFlow::showFlow 
                 }
                 ".tml" -
                 ".html" -
@@ -1055,6 +1057,19 @@ snit::widgetadaptor mainapp {
         $kitbrowser setNodeIcons [concat [$kb getNodeIcons] $Icons(ScriptIcons)]
         $bnb add $kitbrowser -text "Workspace"
         bind $kitbrowser <<SortSeqChanged>> [mymethod setOption %W "KitBrowser,Sort"]
+	
+	set fr [frame $bnb.flowFrame]
+	# Initialize tclFlow with tree widget.
+	set tree [ttk::treeview $fr.flowTree -yscrollcommand [list $fr.ysb set]]
+	tclFlow::init $tree
+	bind $tree <Double-Button-1> "tclFlow::loadRef $tree %x %y"
+
+        scrollbar $fr.ysb -orient vertical -command [list $fr.flowTree yview]
+        grid $fr.flowTree -sticky news -row 0 -column 0
+        grid $fr.ysb -sticky ns -row 0 -column 1
+        grid rowconfigure $fr 0 -weight 1
+        grid columnconfigure $fr 0 -weight 1
+        $bnb add $fr -text "Tcl Flow"
         
         # The code outline
         install codebrowser using ::Tloona::codeoutline $outlinenb.codebrowser \

--- a/src/mainapp.tcl
+++ b/src/mainapp.tcl
@@ -1,4 +1,9 @@
 ## mainapp.tcl (created by Tloona here)
+
+::tcl::tm::path add lib
+
+package require helpBalloon
+
 package require snit 2.3.2
 package require tmw::platform 2.0.0
 package require tmw::icons 1.0
@@ -13,6 +18,7 @@ package require parser::parse 1.0
 #package require tloona::debugger 1.0
 package require comm 4.3
 package require tmw::dialog 2.0.0
+
 
 namespace eval ::Tloona {
 

--- a/src/projectoutline.tcl
+++ b/src/projectoutline.tcl
@@ -93,7 +93,7 @@ snit::widgetadaptor codeoutline {
     method createToolbar {} {
         global Icons
         set f [$self dropframe showcfg -toolbar tools -image $Tmw::Icons(ActWatch) \
-            -separate 1  -hidecmd [mymethod onFilter] -relpos 0]
+            -tip "Show Config" -separate 1  -hidecmd [mymethod onFilter] -relpos 0]
         $self CreateShowButtons $f
         
         # the filter-by-type variables
@@ -107,7 +107,7 @@ snit::widgetadaptor codeoutline {
         set ShowingNodes(private) 1
         
         $self toolbutton collapse -toolbar tools -image $Icons(Collapse) \
-            -type command -separate 0 -command [mymethod collapseAll]
+            -tip "Collapse" -type command -separate 0 -command [mymethod collapseAll]
     }
     
     ## \brief Creates a contextmenu and displays it

--- a/src/tclFlow.tcl
+++ b/src/tclFlow.tcl
@@ -1,0 +1,697 @@
+#!/bin/sh
+
+# Rework to use more procs and be able to embed into another 
+# application
+
+# The idea here is to scan the files in one pass to extract all of the 
+# proc definitions, and build an array of procnames and the files they exist
+# in (make that a list -  ;# flowProcDefs($procName) [list $fileName $lineNumber] 
+#  
+# Then, scan the files again, this time marking down which procs are called 
+# from within other procs, and creating an array 
+#   flowCallTree($procName) [list $firstProc $nextProc $nextProc] 
+#  
+# Then figure out what's going on from the calltree list with a toposort.
+
+
+namespace eval tclFlow {
+
+  variable flowArray
+  variable flowProcDefs
+  variable flowCallTree
+
+  proc DEBUG {string {mark {1}} } {
+    variable flowArray
+
+    if {$flowArray(debugLevel) >$mark} {
+      puts $flowArray(debugChannel) $string
+    }
+  }
+  
+################################################################
+#   proc init {tree}--
+#    Initialize retained variables.
+# Arguments
+#   tree 	A tree widget if displayFlow will be used.
+# 
+# Globals
+#   NONE
+# 
+# Results
+#   Updates flowArray
+# 
+  proc init {{tree {}} } {
+    variable flowArray
+    set flowArray(tree) $tree
+    set flowArray(debugChannel) stderr
+    set flowArray(debugLevel) 0
+    set flowArray(filelist) {}
+  }
+  
+################################################################
+#   proc addFile {args}--
+#    Add a file to the list of files to check.
+#    Only adds files once, no duplicates in list.
+# Arguments
+#   args	List of files to add
+# 
+# Globals
+#   NONE
+# 
+# Results
+#   Update flowArray
+# 
+  proc addFile {args} {
+    variable flowArray
+    foreach fileName $args {
+      if {[lsearch $flowArray(filelist) $fileName] < 0} {
+        lappend flowArray(filelist) $fileName
+      }
+    }
+  }
+  
+################################################################
+#   proc showFlow {start}--
+#    Show the flow in a tree widget
+# Arguments
+#   start	The top of the flow diagram
+# 
+# Globals
+#   NONE
+# 
+# Results
+#   Updates flowArray, modified widget.
+# 
+  proc showFlow {} {
+    variable flowArray
+
+    $flowArray(tree) delete [$flowArray(tree) children {}]
+    foreach ff $flowArray(filelist) {
+      scanForSource [file tail $ff] [file dirname $ff]
+    }
+
+    walkFilelist 
+    extractDefinedProcs 
+    extractRelationShips 
+    set sorted [tclFlow::sortEm]
+    displayTree  {} [lindex $sorted end]
+  }
+
+################################################################
+#   proc printFlow {start}--
+#    Show the flow in a tree widget
+# Arguments
+#   start	The top of the flow diagram
+# 
+# Globals
+#   NONE
+# 
+# Results
+#   Updates flowArray, modified widget.
+# 
+  proc printFlow {} {
+    variable flowArray
+
+    $flowArray(tree) delete [$flowArray(tree) children {}]
+    foreach ff $flowArray(filelist) {
+      scanForSource [file tail $ff] [file dirname $ff]
+    }
+
+    walkFilelist 
+    extractDefinedProcs 
+    extractRelationShips 
+    set sorted [tclFlow::sortEm]
+    printTree 0 [lindex $sorted end] $sorted
+  }
+
+################################################################
+#   proc scanForSource {filename {path {}}}--
+#    Scans files recursively for "source" commands
+#    Does NOT follow package requires (yet)
+# Arguments
+#   filename	Name of file to scan
+#   path	Optional path to prepend
+# 
+# Globals
+#   
+# 
+# Results
+#   Updates flowArray(fileList)
+# 
+  proc scanForSource {filename {path {}}} {
+    variable flowArray
+
+#    set filename [file join $path $filename]
+    DEBUG "Scanning $filename"
+
+    addFile $path/$filename
+
+    set fail [catch {open $path/$filename "r"} infl]
+    if {$fail} {
+      puts "Can't open $filename"
+      puts "$::errorInfo"
+      return -1
+    }
+    
+    set d [read $infl]
+
+    foreach line [split $d \n] {
+      set lst [split $line ";"]
+      foreach ln $lst {
+	set ln [string trim $ln]
+	if {[string first source $ln] == 0} {
+	  set newfile [lindex $ln 1]
+	  set fail [catch {subst $newfile} newfile]
+	  DEBUG "NEW FILE: $newfile"
+	  if {$fail} {return 1}
+	  set fail [catch {scanForSource $newfile $path}]
+	  if {$fail} {
+	    error "FAILED TO LOAD: $newfile"
+	  }
+	}
+      }
+    }
+    close $infl
+    return 0
+  }
+
+  ################################################################
+  # ProcessArgs {}--
+  # Evaluate the command line arguments, in particular, allows an global
+  #  variable to be set from the command line.
+  #
+  # Arguments
+  #   NONE
+  # 
+  # Globals
+  #   Everything in flowGlobalList
+  # 
+  # Results
+  #   Global variables may get modified
+  # 
+  proc ProcessArgs {argv} {
+    variable flowArray
+
+    for {set i 0} {$i < [llength $argv]} {incr i} {
+      set arg [lindex $argv $i]
+
+      if {[string first "-" $arg] == 0} {
+	set arg [string range $arg 1 end]
+
+	incr i
+
+	set val [lindex $argv $i]
+	set cmd [string range $arg 0 0]
+
+	set arg [string range $arg 1 end]
+
+	switch $cmd {
+	"A" {
+	    eval [list set flowArray($arg) $val]
+	  }
+	"S" {
+	    eval [list set $arg $val]
+	  }
+	}
+      } else {
+	lappend flowArray(filelist) $arg
+      }
+    }
+  }
+
+
+  ################################################################
+  # printTree {indent start {lst {}} }--
+  #    Print a tree to the stdout
+  # Arguments
+  #   indent	Number of spaces to indent - call with 0 - 
+  #               other values provided by recursion
+  # 
+  # Globals
+  #   Everything in flowGlobalList
+  # 
+  # Results
+  #   Generates output.
+  # 
+  proc printTree {indent start {lst {}}} {
+    variable flowArray
+
+    variable flowProcDefs
+    variable flowCallTree
+
+    set spaces "                                                           "
+
+
+    puts -nonewline [string range $spaces 0 $indent]
+
+;# Check that we have a valid name -  might be error return from tsort.
+
+    if {![info exists flowCallTree($start)]} {return}
+
+    set info ""
+    if {[info exists flowProcDefs($start)]} {
+      set info "<[lindex $flowProcDefs($start) 0]\
+	[lindex $flowProcDefs($start) 1]>"
+    }
+
+    puts "$start $info"
+
+    if {[llength $flowCallTree($start)] > 1} {
+      set valid 1
+
+      if {[string first "global." $start] == 0} {
+	set valid 0
+
+      }
+
+      set ltmp [lrange $flowCallTree($start) $valid end]
+      set last [expr {80 - $indent - 7}]
+
+      if {[llength $ltmp] > 0} {
+	# puts -nonewline [string range $spaces 0 $indent]
+	# puts "(calls) $ltmp"
+
+	while {$ltmp != ""} {
+	  if {[string length $ltmp] <= $last} {
+	    set prt $ltmp
+	    set ltmp ""
+	  } else {
+	    set stmp [string range $ltmp 0 $last]
+	    set end [string last " " $stmp]
+	    set prt [string trim [string range $ltmp 0 $end]]
+	    set ltmp [string trim [string range $ltmp $end end]]
+	  }
+	  puts -nonewline [string range $spaces 0 $indent]
+	  #        puts "calls: $prt"
+	  puts "----> $prt"
+	}
+      } else {
+        puts ""
+	return
+      }
+
+;# Check for cycles, and kill this run if one exists
+      if {[lsearch $lst $start] >= 0} {return}
+
+      lappend lst $start
+
+      incr indent 4
+      foreach nm $flowCallTree($start) {
+	if {([info exists flowCallTree($nm)]) &&(![string match $start $nm])} {
+	  printTree $indent $nm $lst
+	}
+      }
+    }
+  }
+
+  ################################################################
+  # displayTree {tree parent start {lst {}} }--
+  #    Display a tree in a ttk::treeview widget
+  # Arguments
+  #   tree	Name of tree
+  #   parent	Parent node - {} for start, other values via recursion
+  #   start	What to insert
+  #   lst		subordinate items to
+  # Globals
+  #   ALL
+  # 
+  # Results
+  #   Widget display is modified
+  # 
+  proc displayTree {parent start {lst {}}} {
+    variable flowArray
+    variable flowProcDefs
+    variable flowCallTree
+    
+    if {$flowArray(tree) eq ""} {return} else {set tree $flowArray(tree)}
+
+    DEBUG "-&*-- displayTree tree $tree parent $parent start $start lst $lst "
+
+;# Check that we have a valid name -  might be error return from tsort.
+
+    if {![info exists flowCallTree($start)]} {return}
+
+    set info ""
+    if {[info exists flowProcDefs($start)]} {
+      set info "<[lindex $flowProcDefs($start) 0]\
+	[lindex $flowProcDefs($start) 1]>"
+    }
+    set useMe 1
+    foreach ch [$tree children $parent] {
+      if {[$tree item $ch -text] eq $start} {
+	set useMe 0
+	set id $ch
+      }
+    }
+    DEBUG "CHILDREN: [$tree children $parent]"
+    if {$useMe} {
+      DEBUG "AA  set id \[$tree insert $parent end -text $start -values $info]"
+      set id [$tree insert $parent end -text $start -values $info]
+    }
+
+
+    if {[llength $flowCallTree($start)] > 1} {
+      set valid 1
+
+      if {[string first "global." $start] == 0} {
+	set valid 0
+
+      }
+
+      set ltmp [lrange $flowCallTree($start) $valid end]
+
+      if {[llength $ltmp] > 0} {
+	while {$ltmp != ""} {
+	  set stmp [string range $ltmp 0 end]
+	  set end [string last " " $stmp]
+	  if {$end < 0} {
+	    set end "end"
+	  }
+	  set prt [string trim [string range $ltmp 0 $end]]
+	  set ltmp [string trim [string range $ltmp $end end]]
+	  if {[string length $ltmp] == 1} {set ltmp ""}
+	  DEBUG "XX	$tree insert $id end -text $prt "
+	  #	$tree insert $id end -text $prt 
+	}
+      } else {
+        return
+      }
+
+;# Check for cycles, and kill this run if one exists
+      if {[lsearch $lst $start] >= 0} {return}
+
+      lappend lst $start
+
+      incr indent 4
+      foreach nm $flowCallTree($start) {
+	if {([info exists flowCallTree($nm)]) &&(![string match $start $nm])} {
+	  displayTree $id $nm $lst
+	}
+      }
+    }
+  }
+
+  ################################################################
+  # extractDefinedProcs {}--
+  #    Find all the procs defined with a "proc" call.
+  # Arguments
+  #   NONE
+  # 
+  # Globals
+  #   ALL
+  # 
+  # Results
+  #   Updates flowProcDefs
+  # 
+  proc extractDefinedProcs {} {
+    variable flowArray
+
+    variable flowProcDefs
+    variable flowCallTree
+
+    # extract all of the defined procs from the files,
+    # and put them into a list.
+
+    foreach fl $flowArray(filelist) {
+      set fail [catch {open $fl "r"} infl]
+      if {$fail} {
+	puts "Failed to open $fl"
+	puts "$::errorCode: $::errorInfo"
+	set ::errorInfo ""
+	set ::errorCode ""
+	continue
+      }
+
+      set lineNum 0
+
+      set flowProcDefs(global.$fl) [list $fl 0 global]
+
+      while {![eof $infl]} {
+	set len [gets $infl line]
+	incr lineNum
+
+	if {$len > 2} {
+	  set line [string trim $line]
+	  set type ""
+	  lassign [regexp -all -inline {\S+} $line] type name
+
+	  if {($type eq "proc") ||($type eq "method")} {
+	    set m1 ""
+	    set m2 ""
+	    set m3 ""
+	    set mm [regexp "$type\[ 	]+(\[^ ]+)\[ 	]+\{\[ 	]*(\[^\}]*)\[\
+	      	]*\}" $line m1 m2 m3]
+	    DEBUG "regexp result: $mm -- $line" 1
+	    DEBUG "$m1 $m2 $m3" 1
+	    if {$mm} {
+	      set flowProcDefs($m2) [list $fl $lineNum $m3]
+	      if {![info exists flowCallTree($m2)]} {
+		set flowCallTree($m2) $m2
+		lappend flowDefine(global.$fl) $m2
+	      } 
+	    }
+	  }
+	}
+      }
+      close $infl
+    }
+
+    foreach proc [array names flowProcDefs] {
+      DEBUG "$proc : $flowProcDefs($proc)" 4
+    }
+  }
+
+  ################################################################
+  # proc extractRelationShips {}--
+  #    Extract the relationships.
+  #    Find out who calls who
+  # Arguments
+  #   NONE
+  # 
+  # Globals
+  #   ALL
+  # 
+  # Results
+  #   Updates flowCallTree, afterCallTree flowProcDefs and more
+  # 
+  proc extractRelationShips {} {
+    variable flowArray
+
+    variable flowProcDefs
+    variable flowCallTree
+
+    foreach fl $flowArray(filelist) {
+      set fail [catch {open $fl "r"} infl]
+      if {$fail} {
+	puts "Failed to open $fl"
+	puts "$::errorCode: $::errorInfo"
+	set ::errorInfo ""
+	set ::errorCode ""
+	continue
+      }
+
+      set lineNum 0
+
+      # A proc can be invoked:
+      # 1) by itself
+      # 2) as part of an if conditional
+      # 3) within an inline if action
+      # 4) as part of a for conditional
+      # 5) as part of a while conditional
+      # 6) as part of an inline for/while action
+      # 7) as a catch argument
+      # 8) as an eval argument
+      #
+      #  Perhaps all of this can be ignored for a first pass, though...
+      #  just do a check to see if a word is in my proc list.
+
+
+      set lineNum 0
+      set current global.$fl
+
+      # These are used to see if the script is currently looking at a proc
+      #  definition.  It moves the 'current' pointer back to global space
+      #  when procs are not being defined.
+
+      set scr ""
+      set inproc 0
+
+
+      while {![eof $infl]} {
+	set len [gets $infl line]
+	incr lineNum
+
+	if {$len > 2} {
+	  set line [string trim $line]
+	  lassign [regexp -all -inline {\S+} $line] type name
+
+	  if {($type eq "proc") ||($type eq "method")} {
+	    set inproc 1
+
+	    set scr $line
+
+	    set mm [regexp "$type +(\[^ ]+) +\{ *(\[^\}]*) *\}" $line m1 m2 m3]
+	    if {$mm} {
+	      set current $m2
+	    }
+	  } else {
+	    if {$inproc} {
+	      append scr $line
+
+	      if {[info complete $scr]} {
+		# puts "SET INPROC 0 - $name"
+		set inproc 0
+
+		set current global.$fl
+	      }
+	    }
+	    regsub -all ";" $line " " line
+	    set line [string trim $line] 
+	    # puts "LINE: [string first "#" $line] -- $line"
+	    if {([string first "#" $line] != 0) &&
+	        ([string first "bind" $line] != 0)} {
+	      set lst [split $line " {}\[\]\(\)"] 
+	      # puts "LINE: $line :: $lst :: $current :: $inproc"
+	      foreach word $lst {
+		set word [string trim $word]
+		if {([info exists flowProcDefs($word)]) &&([string first\
+		  "after " $line] < 0) &&((![info exists\
+		  flowCallTree($current)]) ||([lsearch $flowCallTree($current)\
+		  $word] == -1))} {
+		  lappend flowCallTree($current) $word
+		}
+		if {([info exists flowProcDefs($word)]) &&
+		    ([string first "after " $line] >= 0) &&
+		    ((![info exists afterCallTree($current)]) ||
+		     ([lsearch $afterCallTree($current) $word] == -1))} {
+		  lappend afterCallTree($current) $word
+		}
+	      }
+	    }
+	  }
+	}
+      }
+      close $infl
+    }
+  }
+
+  ################################################################
+  # proc sortEm {}--
+  #    Return a topo-sorted list of stuff 
+  # Arguments
+  #   NONE
+  # 
+  # Globals
+  #   flowCallTree, flowDefine, 
+  # 
+  # Results
+  #   
+  # 
+
+  proc sortEm {} {
+    variable flowArray
+
+    variable flowCallTree
+
+    foreach aname {flowDefine flowCallTree afterCallTree} {
+      foreach {k v} [array get $aname] {
+	lappend lst [list $k $v]
+      }
+    }
+
+    set sorted [topoSort::topoSort $lst]
+
+    # DEBUG OUTPUT
+    if {0} {
+      set of [open sorted w]
+      puts $of $sorted
+      close $of
+      puts "----- SORTED ----- "
+      puts "$sorted"
+      puts "----- END SORTED ----- "
+    }
+
+    if {0} {
+      puts "...... Contingency Tree ...... "
+      foreach nm $sorted {
+	printTree 0 $nm
+      }
+    }
+
+    return $sorted
+  }
+
+  ################################################################
+  # proc walkFilelist {}--
+  # Walk down the tree and see what we can find in order.
+  #  This expects the files to be in *some* rough order
+  # Arguments
+  #   NONE
+  # 
+  # Globals
+  #   Uses flowArray(filelist)
+  # 
+  # Results
+  #   Updates tables in flowArray
+  # 
+  proc walkFilelist {} {
+    variable flowArray
+
+    variable flowProcDefs
+
+    DEBUG "FLOW TREES"
+
+    foreach fl $flowArray(filelist) {
+      set fail [catch {open $fl "r"} infl]
+      if {$fail} {
+	puts "Failed to open $fl"
+	puts "$::errorCode: $::errorInfo"
+	set ::errorInfo ""
+	set ::errorCode ""
+	continue
+      }
+
+      set lineNum 0
+
+      set current global
+
+      while {![eof $infl]} {
+	set len [gets $infl line]
+	incr lineNum
+
+	if {$len > 2} {
+	  set line [string trim $line]
+	  if {([string first "proc " $line] == 0) ||([string first\
+	    "proc	" $line] == 0)} {
+	    set mm [regexp "proc +(\[^ ]+) +\{ *(\[^\}]*) *\}" $line m1 m2 m3]
+	    if {$mm} {
+	      set current $m2
+	    }
+	  } else {
+	    regsub -all ";" $line " " line
+	    set line [string trim $line] 
+	    # puts "LINE: [string first  "#" $line] -- $line"
+	    if {[string first "#" $line] != 0} {
+	      set lst [split $line " {}\[\]\(\)"]
+	      foreach word $lst {
+		set word [string trim $word]
+		if {([info exists flowProcDefs($word)])} {
+		  # puts "INFO EXISTS: $word - $flowProcDefs($word)"
+		}
+	      }
+	    }
+	  }
+	}
+      }
+      close $infl
+    }
+  }
+
+  proc loadRef {tree x y} {
+    variable flowProcDefs
+    set id [$tree identify item $x $y]
+    set txt [$tree item $id -text]
+    set fileNm [lindex $flowProcDefs($txt) 0]
+    $::TloonaApplication openFile $fileNm 0
+  }
+}

--- a/src/tmw-platform/platform.tcl
+++ b/src/tmw-platform/platform.tcl
@@ -246,6 +246,11 @@ namespace eval ::Tmw {
             if {[set i [lsearch $nargs -accelerator]] >= 0} {
                 set nargs [lreplace $nargs $i [incr i]]
             }
+	    if {[set pos [lsearch $nargs -text]] >= 0} {
+	      incr pos
+	      set tip [lindex $nargs $pos]
+	      lappend nargs -tip $tip
+	    }
             set toolButton [$self toolbutton $name -type $type -toolbar $toolbar {*}$nargs]
             
             # if it is a cascade, create a menu for it. This is filled

--- a/src/tmw-toolbarframe/toolbarframe.tcl
+++ b/src/tmw-toolbarframe/toolbarframe.tcl
@@ -257,10 +257,15 @@ namespace eval ::Tmw {
     method toolbutton {name args} {
         set toolbar ""
         set type ""
+        set tip ""
         set stickto "front"
         set separate 1
-        
+
         # check for special arguments
+        if {[set i [lsearch $args -tip]] >= 0} {
+            lvarpop args $i
+            set tip [lvarpop args $i]
+        }
         if {[set i [lsearch $args -type]] >= 0} {
             lvarpop args $i
             set type [lvarpop args $i]
@@ -400,6 +405,10 @@ namespace eval ::Tmw {
         } else {
             eval pack $b $packArgs
         }
+	
+	if {$tip ne ""} {
+	  catch {balloon $b $tip}
+	}
         
         lappend Buttons($toolbar) $type $T.$path $stickto
         return $T.$path
@@ -429,10 +438,18 @@ namespace eval ::Tmw {
     #
     # \return the frame where to place widgets
     method dropframe {name args} {
+        set tip ""
+
         if {[set idx [lsearch $args -toolbar]] < 0} {
             error "-toolbar must be provided"
         }
         set toolbar [lindex $args [incr idx]]
+
+        if {[set idx [lsearch $args -tip]] >= 0} {
+            set args [lreplace $args $idx $idx]
+            set tip [lindex $args $idx]
+            set args [lreplace $args $idx $idx]
+        }
         
         set anchor nw
         if {[set idx [lsearch $args -anchor]] >= 0} {
@@ -490,7 +507,7 @@ namespace eval ::Tmw {
         
         set Dropframes($toolbar,$name) \
             [list [ttk::frame $win.$toolbar,$name] \
-                [$self toolbutton $name {*}$args] $anchor $relpos $showcmd $hidecmd]
+                [$self toolbutton $name {*}$args -tip $tip] $anchor $relpos $showcmd $hidecmd]
         
         lindex $Dropframes($toolbar,$name) 0
     }


### PR DESCRIPTION
This was more extensive.
I added a helpBalloon module l that I pulled from the wiki a few years ago,
Added a tcl module path add to find it to mainapp.tcl
Modified the toolbutton and dropframe methods to accept a -tip argument
And tweaked codebrowser.tcl and platform.tcl to put the tooltips onto the buttons.
I tested this on Linux (Ubuntu 16.04.4), but not on Mac or Windows.